### PR TITLE
Add show/stage/run cli subcommands

### DIFF
--- a/compaction/cli.py
+++ b/compaction/cli.py
@@ -1,12 +1,14 @@
+import pathlib
 import sys
 from typing import Optional, TextIO
 
 import click
+import numpy as np  # type: ignore
 import pandas  # type: ignore
 import yaml
 
 from ._version import get_versions
-from .compaction import compact
+from .compaction import compact as _compact
 
 __version__ = get_versions()["version"]
 del get_versions
@@ -34,8 +36,28 @@ def load_config(file: Optional[TextIO] = None):
         "rho_void": 1000.0,
     }
     if file is not None:
-        conf.update(yaml.load(file))
+        conf.update(yaml.safe_load(file))
     return conf
+
+
+def _contents_of_input_file(infile: str) -> str:
+    params = load_config()
+
+    def as_csv(data, header=None):
+        with StringIO() as fp:
+            np.savetxt(fp, data, header=header, delimiter=",", fmt="%.1f")
+            contents = fp.getvalue()
+        return contents
+
+    contents = {
+        "config": yaml.dump(params, default_flow_style=False),
+        "porosity": as_csv(
+            [[1.0, 0.4], [1.0, 0.4], [1.0, 0.2]],
+            header="Layer Thickness [m], Porosity [-]",
+        ),
+    }
+
+    return contents[infile]
 
 
 def run_compaction(
@@ -44,9 +66,9 @@ def run_compaction(
     src = src or sys.stdin
     dest = dest or sys.stdout
 
-    init = pandas.read_csv(src, names=("dz", "porosity"), dtype=float)
+    init = pandas.read_csv(src, names=("dz", "porosity"), dtype=float, comment="#")
 
-    porosity_new = compact(init.dz.values, init.porosity.values, **kwds)
+    porosity_new = _compact(init.dz.values, init.porosity.values, **kwds)
 
     dz_new = init.dz * (1 - init.porosity) / (1 - porosity_new)
 
@@ -54,18 +76,53 @@ def run_compaction(
     out.to_csv(dest, index=False, header=False)
 
 
-@click.command()
+@click.group()
+@click.version_option()
+def compact() -> None:
+    """Compact layers of sediment.
+
+    \b
+    Examples:
+
+      Create a folder with example input files,
+
+        $ compact setup compact-example
+
+      Run a simulation using the examples input files,
+
+        $ compact run compact-example/porosity.csv
+    """
+    pass
+
+
+@compact.command()
 @click.version_option(version=__version__)
 @click.option("-v", "--verbose", is_flag=True, help="Emit status messages to stderr.")
 @click.option("--dry-run", is_flag=True, help="Do not actually run the model")
+# @click.option(
+#     "--config", default="config.yaml", type=click.File(mode="r"), help="Configuration file"
+# )
 @click.option(
-    "--config", default=None, type=click.File(mode="r"), help="Configuration file"
+    "--config",
+    type=click.Path(
+        exists=False, file_okay=True, dir_okay=False, readable=True, allow_dash=False
+    ),
+    default="config.yaml",
+    is_eager=True,
+    help="Read configuration from PATH.",
 )
 @click.argument("src", type=click.File(mode="r"))
 @click.argument("dest", default="-", type=click.File(mode="w"))
-def main(src: TextIO, dest: TextIO, config: TextIO, dry_run: bool, verbose: bool):
+def run(src: TextIO, dest: TextIO, config: str, dry_run: bool, verbose: bool) -> None:
 
-    params = load_config(config)
+    config_path = pathlib.Path(config)
+    if src.name is not None:
+        rundir = pathlib.Path(src.name).parent.resolve()
+    else:
+        rundir = pathlib.Path(".")
+
+    with open(rundir / config_path) as fp:
+        params = load_config(fp)
     if verbose:
         click.secho(yaml.dump(params, default_flow_style=False), err=True)
 
@@ -76,3 +133,40 @@ def main(src: TextIO, dest: TextIO, config: TextIO, dry_run: bool, verbose: bool
 
         click.secho("💥 Finished! 💥", err=True, fg="green")
         click.secho("Output written to {0}".format(dest.name), err=True, fg="green")
+
+
+@compact.command()
+@click.argument(
+    "infile",
+    type=click.Choice(["config", "porosity"]),
+)
+def show(infile: str) -> None:
+    """Show example input files."""
+    click.secho(_contents_of_input_file(infile), err=False)
+
+
+@compact.command()
+@click.argument(
+    "dest",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, readable=True),
+)
+def setup(dest: str) -> None:
+    """Setup a folder of input files for a simulation."""
+    folder = pathlib.Path(dest)
+
+    files = [pathlib.Path(fname) for fname in ["porosity.csv", "config.yaml"]]
+
+    existing_files = [folder / name for name in files if (folder / name).exists()]
+    if existing_files:
+        for name in existing_files:
+            click.secho(
+                f"{name}: File exists. Either remove and then rerun or choose a different destination folder",
+                err=True,
+            )
+    else:
+        for fname in files:
+            with open(folder / fname, "w") as fp:
+                print(_contents_of_input_file(fname.stem), file=fp)
+        click.secho(str(folder / "porosity.csv"), err=False)
+
+    sys.exit(len(existing_files))

--- a/compaction/cli.py
+++ b/compaction/cli.py
@@ -122,7 +122,7 @@ def compact() -> None:
 def run(src: TextIO, dest: TextIO, config: str, dry_run: bool, verbose: bool) -> None:
     """Run a simulation."""
     config_path = pathlib.Path(config)
-    if src.name is "<stdin>":
+    if src.name == "<stdin>":
         rundir = pathlib.Path(".")
     else:
         rundir = pathlib.Path(src.name).parent.resolve()
@@ -146,8 +146,7 @@ def run(src: TextIO, dest: TextIO, config: str, dry_run: bool, verbose: bool) ->
 
 @compact.command()
 @click.argument(
-    "infile",
-    type=click.Choice(["config", "porosity"]),
+    "infile", type=click.Choice(["config", "porosity"]),
 )
 def show(infile: str) -> None:
     """Show example input files."""
@@ -156,8 +155,7 @@ def show(infile: str) -> None:
 
 @compact.command()
 @click.argument(
-    "dest",
-    type=click.Path(exists=True, file_okay=False, dir_okay=True, readable=True),
+    "dest", type=click.Path(exists=True, file_okay=False, dir_okay=True, readable=True),
 )
 def setup(dest: str) -> None:
     """Setup a folder of input files for a simulation."""
@@ -175,6 +173,6 @@ def setup(dest: str) -> None:
         for fname in files:
             with open(folder / fname, "w") as fp:
                 print(_contents_of_input_file(fname.stem), file=fp)
-        print(str(folder /"porosity.csv"))
+        print(str(folder / "porosity.csv"))
 
     sys.exit(len(existing_files))

--- a/compaction/cli.py
+++ b/compaction/cli.py
@@ -104,9 +104,6 @@ def compact() -> None:
 @click.version_option(version=__version__)
 @click.option("-v", "--verbose", is_flag=True, help="Emit status messages to stderr.")
 @click.option("--dry-run", is_flag=True, help="Do not actually run the model")
-# @click.option(
-#     "--config", default="config.yaml", type=click.File(mode="r"), help="Configuration file"
-# )
 @click.option(
     "--config",
     type=click.Path(
@@ -118,7 +115,6 @@ def compact() -> None:
 )
 @click.argument("src", type=click.File(mode="r"))
 @click.argument("dest", default="-", type=click.File(mode="w"))
-# @click.argument("dest", type=click.File(mode="w"))
 def run(src: TextIO, dest: TextIO, config: str, dry_run: bool, verbose: bool) -> None:
     """Run a simulation."""
     try:

--- a/compaction/cli.py
+++ b/compaction/cli.py
@@ -121,8 +121,17 @@ def compact() -> None:
 # @click.argument("dest", type=click.File(mode="w"))
 def run(src: TextIO, dest: TextIO, config: str, dry_run: bool, verbose: bool) -> None:
     """Run a simulation."""
+    try:
+        from_stdin = src.name == "<stdin>"
+    except AttributeError:
+        from_stdin = True
+    try:
+        from_stdout = dest.name == "<stdout>"
+    except AttributeError:
+        from_stdout = True
+
     config_path = pathlib.Path(config)
-    if src.name == "<stdin>":
+    if from_stdin:
         rundir = pathlib.Path(".")
     else:
         rundir = pathlib.Path(src.name).parent.resolve()
@@ -139,7 +148,7 @@ def run(src: TextIO, dest: TextIO, config: str, dry_run: bool, verbose: bool) ->
         run_compaction(src, dest, **params)
 
         out("💥 Finished! 💥")
-        out("Output written to {0}".format(dest.name))
+        out("Output written to {0}".format("<stdout>" if from_stdout else dest.name))
 
     sys.exit(0)
 

--- a/compaction/cli.py
+++ b/compaction/cli.py
@@ -1,5 +1,6 @@
 import pathlib
 import sys
+from io import StringIO
 from typing import Optional, TextIO
 
 import click

--- a/compaction/cli.py
+++ b/compaction/cli.py
@@ -97,7 +97,7 @@ def compact() -> None:
 
         $ compact run compact-example/porosity.csv
     """
-    pass
+    pass  # pragma: no cover
 
 
 @compact.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,13 +30,17 @@ def test_content(response):
 
 def test_command_line_interface():
     """Test the CLI."""
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     result = runner.invoke(cli.compact, ["--help"])
     assert result.exit_code == 0
 
     result = runner.invoke(cli.compact, ["--version"])
     assert result.exit_code == 0
-    assert "version" in result.output
+    assert "version" in result.stdout
+
+    result = runner.invoke(cli.compact)
+    assert result.exit_code == 0
+    assert "Compact layers of sediment" in result.stdout
 
 
 def test_dry_run(tmpdir, datadir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,7 +155,7 @@ def test_run_to_stdin(tmpdir, datadir):
         )
         assert result.exit_code == 0
 
-        assert result.stdout == actual
+        assert result.stdout.splitlines() == actual.splitlines()
 
 
 def test_setup(tmpdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,10 +29,10 @@ def test_content(response):
 def test_command_line_interface():
     """Test the CLI."""
     runner = CliRunner()
-    result = runner.invoke(cli.main, ["--help"])
+    result = runner.invoke(cli.compact, ["--help"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli.main, ["--version"])
+    result = runner.invoke(cli.compact, ["--version"])
     assert result.exit_code == 0
     assert "version" in result.output
 
@@ -41,7 +41,7 @@ def test_dry_run(tmpdir, datadir):
     with tmpdir.as_cwd():
         runner = CliRunner()
         result = runner.invoke(
-            cli.main,
+            cli.run,
             [
                 "--dry-run",
                 "--config={0}".format(datadir / "config.yaml"),
@@ -58,7 +58,7 @@ def test_verbose(tmpdir, datadir):
     with tmpdir.as_cwd():
         runner = CliRunner()
         result = runner.invoke(
-            cli.main,
+            cli.run,
             [
                 "--verbose",
                 "--config={0}".format(datadir / "config.yaml"),
@@ -81,7 +81,7 @@ def test_constant_porosity(tmpdir, datadir):
     with tmpdir.as_cwd():
         runner = CliRunner()
         result = runner.invoke(
-            cli.main,
+            cli.run,
             [
                 "--config={0}".format(datadir / "config.yaml"),
                 str(datadir / "porosity_profile.txt"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,7 +114,7 @@ def test_setup_with_existing_files(tmpdir, files):
     runner = CliRunner(mix_stderr=False)
     with tmpdir.as_cwd():
         for name in files:
-            with open(name, "w") as fp:
+            with open(name, "w"):
                 pass
 
         result = runner.invoke(cli.setup, ["."])


### PR DESCRIPTION
This pull requests adds the following subcommands to the *compact* program:
* *show*: print an example input file
* *stage*: create a set of example input files
* *run*: run a compaction simulation