### PR TITLE
Fix layer ordering for landlab component

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ in *requirements-testing.txt*.
 
 ## Installation
 
-To install *Compaction* from source, first create a new environment in
+To install *Compaction*, first create a new environment in
 which *Compaction* will be installed. This, although not necessary, will
 isolate the installation so that there won't be conflicts with your
 base *Python* installation. This can be done with *conda* as:
@@ -49,9 +49,24 @@ base *Python* installation. This can be done with *conda* as:
     $ conda create -n compaction python=3
     $ conda activate compaction
 
-To then install *Compaction* into this environment:
+## Stable Release
 
-  $ pip install -e .
+*Compaction*, and its dependencies, can be installed either with *pip*
+or *conda*. Using *pip*:
+
+    $ pip install compaction
+
+Using *conda*:
+
+    $ conda install compaction -c conda-forge
+
+### From Source
+
+After downloading the *Compaction* source code, run the following from
+*Compaction*'s top-level folder (the one that contains *setup.py*) to
+install *Compaction* into the current environment:
+
+    $ pip install -e .
 
 ## Input Files
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ need to create a set of sample files:
 You can now run the simulation:
 
     $ sequence run example/sequence.yaml
+    # Layer Thickness [m], Porosity [-]
     100.0,0.5
     96.18666488709239,0.4801774231522433
     92.78860257194452,0.4611407154102571

--- a/compaction/cli.py
+++ b/compaction/cli.py
@@ -74,9 +74,12 @@ def run_compaction(
     init = pandas.read_csv(src, names=("dz", "porosity"), dtype=float, comment="#")
 
     dz_new = np.empty_like(init.dz)
-    porosity_new = _compact(init.dz.values, init.porosity.values, return_dz=dz_new, **kwds)
+    porosity_new = _compact(
+        init.dz.values, init.porosity.values, return_dz=dz_new, **kwds
+    )
 
     out = pandas.DataFrame.from_dict({"dz": dz_new, "porosity": porosity_new})
+    print("# Layer Thickness [m], Porosity [-]", file=dest)
     out.to_csv(dest, index=False, header=False)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,9 +2,9 @@
 import filecmp
 import os
 
+import numpy as np  # type: ignore
 import pandas  # type: ignore
 import pytest  # type: ignore
-import numpy as np  # type: ignore
 import yaml
 from click.testing import CliRunner
 from numpy.testing import assert_array_almost_equal  # type: ignore
@@ -81,7 +81,9 @@ def test_constant_porosity(tmpdir, datadir):
 
         assert result.exit_code == 0
         assert "Output written to out.txt" in result.stderr
-        phi_actual = pandas.read_csv("out.txt", names=("dz", "porosity"), dtype=float)
+        phi_actual = pandas.read_csv(
+            "out.txt", names=("dz", "porosity"), dtype=float, comment="#"
+        )
 
     assert_array_almost_equal(phi_actual["porosity"], phi_expected)
 
@@ -95,7 +97,8 @@ def test_run_from_stdin(tmpdir, datadir):
 
     with tmpdir.as_cwd():
         result = runner.invoke(
-            cli.run, [
+            cli.run,
+            [
                 "--config={0}".format(datadir / "config.yaml"),
                 path_to_porosity,
                 "expected.txt",
@@ -120,7 +123,8 @@ def test_run_to_stdout(tmpdir, datadir):
 
     with tmpdir.as_cwd():
         result = runner.invoke(
-            cli.run, [
+            cli.run,
+            [
                 "--config={0}".format(datadir / "config.yaml"),
                 path_to_porosity,
                 "expected.txt",
@@ -133,10 +137,8 @@ def test_run_to_stdout(tmpdir, datadir):
 
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
-            cli.run, [
-                "--config={0}".format(datadir / "config.yaml"),
-                path_to_porosity,
-            ],
+            cli.run,
+            ["--config={0}".format(datadir / "config.yaml"), path_to_porosity,],
         )
         assert result.exit_code == 0
         actual_lines = [line.strip() for line in result.stdout.splitlines() if line]
@@ -184,7 +186,9 @@ def test_show(tmpdir):
         with open("porosity.csv", "w") as fp:
             fp.write(result.stdout)
 
-        result = CliRunner(mix_stderr=False).invoke(cli.run, ["porosity.csv", "out.csv"])
+        result = CliRunner(mix_stderr=False).invoke(
+            cli.run, ["porosity.csv", "out.csv"]
+        )
 
         assert (tmpdir / "out.csv").exists()
         assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,7 +138,7 @@ def test_run_to_stdout(tmpdir, datadir):
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             cli.run,
-            ["--config={0}".format(datadir / "config.yaml"), path_to_porosity,],
+            ["--config={0}".format(datadir / "config.yaml"), path_to_porosity],
         )
         assert result.exit_code == 0
         actual_lines = [line.strip() for line in result.stdout.splitlines() if line]

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -233,6 +233,6 @@ def test_run() -> None:
     run_compaction(src=src, dest=dest, porosity_max=0.5)
     dest.seek(0)
 
-    data = pandas.read_csv(dest, names=("dz", "porosity"), dtype=float)
+    data = pandas.read_csv(dest, names=("dz", "porosity"), dtype=float, comment="#")
 
     assert np.all(data.porosity.values == approx(phi_1))

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -23,14 +23,14 @@ def test_matches_module(grid):
     compact = Compact(grid, porosity_min=0.0, porosity_max=0.5)
     compact.calculate()
 
-    assert_array_almost_equal(grid.event_layers["porosity"][:-1, :], phi_expected)
+    assert_array_almost_equal(grid.event_layers["porosity"][-1::-1, :], phi_expected)
 
 
 def test_init_without_layers_added(grid):
     compact = Compact(grid)
     compact.run_one_step()
-
-    assert grid.event_layers.dz == approx(0.0)
+    assert grid.event_layers.number_of_layers == 0
+    # assert grid.event_layers.dz == approx(0.0)
 
 
 @mark.parametrize("size", (10, 100, 1000, 10000))
@@ -43,11 +43,11 @@ def test_grid_size(benchmark, size):
     compact = Compact(grid, porosity_min=0.0, porosity_max=0.5)
     benchmark(compact.calculate)
 
-    assert np.all(grid.event_layers["porosity"][1:] < 0.5)
-    assert grid.event_layers["porosity"][0] == approx(0.5)
+    assert np.all(grid.event_layers["porosity"][:-1] < 0.5)
+    assert grid.event_layers["porosity"][-1] == approx(0.5)
 
-    assert np.all(grid.event_layers.dz[0] == approx(1.0))
-    assert np.all(grid.event_layers.dz[1:] < 1.0)
+    assert np.all(grid.event_layers.dz[-1] == approx(1.0))
+    assert np.all(grid.event_layers.dz[:-1] < 1.0)
 
 
 def test_init_with_layers_added(grid):
@@ -56,11 +56,11 @@ def test_init_with_layers_added(grid):
     compact = Compact(grid, porosity_min=0.1, porosity_max=0.7)
     compact.run_one_step()
 
-    assert np.all(grid.event_layers["porosity"][1:] < 0.7)
-    assert grid.event_layers["porosity"][0] == approx(0.7)
+    assert np.all(grid.event_layers["porosity"][:-1] < 0.7)
+    assert grid.event_layers["porosity"][-1] == approx(0.7)
 
-    assert np.all(grid.event_layers.dz[0] == approx(100.0))
-    assert np.all(grid.event_layers.dz[1:] < 100.0)
+    assert np.all(grid.event_layers.dz[-1] == approx(100.0))
+    assert np.all(grid.event_layers.dz[:-1] < 100.0)
 
 
 def test_layers_compact_evenly(grid):


### PR DESCRIPTION
This pull request fixes a bug where the ordering of layers within the *landlab* component was reversed. In *landlab*, layer 0 is the bottom layer but in *compaction* layer 0 is the surface layer.