### PR TITLE
Add requirements.txt to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include versioneer.py
 include compaction/_version.py
 include LICENSE
+include requirements.txt


### PR DESCRIPTION
Add *requirements.txt* to the *MANIFEST* so that it's packaged with the distribution. The requirements file is read by *setup.py* and so must be included with the distribution.