### PR TITLE
Change name of cli command to compaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
 - pytest -vvv --cov=compaction --cov-report=xml:$(pwd)/coverage.xml --mypy
 - compaction --help
 - compaction --version
-- compaction generate compact.toml
+- compaction generate compaction.toml
 - compaction generate porosity.csv
 - mkdir example
 - compaction --cd=example setup run

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,10 @@ script:
 - pip install -r requirements-testing.txt
 - pip install pytest pytest-cov pytest-datadir pytest-benchmark coveralls
 - pytest -vvv --cov=compaction --cov-report=xml:$(pwd)/coverage.xml --mypy
-- compact --help
-- compact --version
-- compact generate compact.toml
-- compact generate porosity.csv
+- compaction --help
+- compaction --version
+- compaction generate compact.toml
+- compaction generate porosity.csv
 - mkdir example
-- compact --cd=example setup run
+- compaction --cd=example setup run
 after_success: coveralls

--- a/compaction/cli.py
+++ b/compaction/cli.py
@@ -13,7 +13,6 @@ import tomlkit as toml  # type: ignore
 
 from .compaction import compact as _compact
 
-
 out = partial(click.secho, bold=True, err=True)
 err = partial(click.secho, fg="red", err=True)
 
@@ -103,7 +102,7 @@ def load_config(stream: Optional[TextIO] = None):
         Config parameters.
     """
     conf = {
-        "compact" : {
+        "compaction": {
             "constants": {
                 "c": 5e-8,
                 "porosity_min": 0.0,
@@ -115,7 +114,7 @@ def load_config(stream: Optional[TextIO] = None):
     }
     if stream is not None:
         try:
-            local_params = toml.parse(stream.read())["compact"]
+            local_params = toml.parse(stream.read())["compaction"]
         except KeyError:
             local_params = {"constants": {}}
 
@@ -124,9 +123,9 @@ def load_config(stream: Optional[TextIO] = None):
         except KeyError:
             local_constants = {}
 
-        conf["compact"]["constants"].update(local_constants)
+        conf["compaction"]["constants"].update(local_constants)
 
-    return _tomlkit_to_popo(conf).pop("compact")
+    return _tomlkit_to_popo(conf).pop("compaction")
 
 
 def _contents_of_input_file(infile: str) -> str:
@@ -139,7 +138,7 @@ def _contents_of_input_file(infile: str) -> str:
         return contents
 
     contents = {
-        "compact.toml": toml.dumps(dict(compact=params)),
+        "compaction.toml": toml.dumps(dict(compacton=params)),
         "porosity.csv": as_csv(
             [[100.0, 0.5], [100.0, 0.5], [100.0, 0.5]],
             header="Layer Thickness [m], Porosity [-]",
@@ -172,7 +171,7 @@ def run_compaction(src: str, dest: str, **kwds) -> None:
     type=click.Path(exists=True, file_okay=False, dir_okay=True, readable=True),
     help="chage to directory, then execute",
 )
-def compact(cd) -> None:
+def compaction(cd) -> None:
     """Compact layers of sediment.
 
     \b
@@ -181,22 +180,22 @@ def compact(cd) -> None:
       Create a folder with example input files,
 
         $ mkdir compaction-example && cd compaction-example
-        $ compact setup
+        $ compaction setup
 
       Run a simulation using the examples input files,
 
-        $ compact run
+        $ compaction run
     """
     os.chdir(cd)  # pragma: no cover
 
 
-@compact.command()
+@compaction.command()
 @click.version_option()
 @click.option("-v", "--verbose", is_flag=True, help="Emit status messages to stderr.")
 @click.option("--dry-run", is_flag=True, help="Do not actually run the model")
 def run(dry_run: bool, verbose: bool) -> None:
     """Run a simulation."""
-    with open("compact.toml", "r") as fp:
+    with open("compaction.toml", "r") as fp:
         params = load_config(fp)
 
     if verbose:
@@ -211,19 +210,19 @@ def run(dry_run: bool, verbose: bool) -> None:
         out("Output written to {0}".format("porosity-out.csv"))
 
 
-@compact.command()
+@compaction.command()
 @click.argument(
-    "infile", type=click.Choice(["compact.toml", "porosity.csv"]),
+    "infile", type=click.Choice(["compaction.toml", "porosity.csv"]),
 )
 def generate(infile: str) -> None:
     """Show example input files."""
     print(_contents_of_input_file(infile))
 
 
-@compact.command()
+@compaction.command()
 def setup() -> None:
     """Setup a folder of input files for a simulation."""
-    files = [pathlib.Path(fname) for fname in ["porosity.csv", "compact.toml"]]
+    files = [pathlib.Path(fname) for fname in ["porosity.csv", "compaction.toml"]]
 
     existing_files = [str(file_) for file_ in files if file_.exists()]
     if existing_files:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     setup_requires=[],
     packages=find_packages(),
     entry_points={
-        "console_scripts": ["compact=compaction.cli:compact"],
+        "console_scripts": ["compaction=compaction.cli:compaction"],
         "landlab.components": ["Compact=compaction.landlab:Compact"],
     },
     version="v0.3.0.dev0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,27 +14,25 @@ from compaction import cli, compact
 def test_command_line_interface():
     """Test the CLI."""
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(cli.compact, ["--help"])
+    result = runner.invoke(cli.compaction, ["--help"])
     assert result.exit_code == 0
 
-    result = runner.invoke(cli.compact, ["--version"])
+    result = runner.invoke(cli.compaction, ["--version"])
     assert result.exit_code == 0
     assert "version" in result.stdout
 
-    result = runner.invoke(cli.compact)
+    result = runner.invoke(cli.compaction)
     assert result.exit_code == 0
     assert "Compact layers of sediment" in result.stdout
 
 
 def test_dry_run(tmpdir, datadir):
     with tmpdir.as_cwd():
-        shutil.copy(datadir / "compact.toml", ".")
+        shutil.copy(datadir / "compaction.toml", ".")
         shutil.copy(datadir / "porosity.csv", ".")
 
         runner = CliRunner()
-        result = runner.invoke(
-            cli.run, ["--dry-run"],
-        )
+        result = runner.invoke(cli.run, ["--dry-run"],)
         assert result.exit_code == 0
         assert "Nothing to do" in result.output
         assert not (tmpdir / "porosity-out.csv").exists()
@@ -42,13 +40,11 @@ def test_dry_run(tmpdir, datadir):
 
 def test_verbose(tmpdir, datadir):
     with tmpdir.as_cwd():
-        shutil.copy(datadir / "compact.toml", ".")
+        shutil.copy(datadir / "compaction.toml", ".")
         shutil.copy(datadir / "porosity.csv", ".")
 
         runner = CliRunner()
-        result = runner.invoke(
-            cli.run, ["--verbose"],
-        )
+        result = runner.invoke(cli.run, ["--verbose"],)
         assert result.exit_code == 0
         assert (tmpdir / "porosity-out.csv").exists()
 
@@ -59,7 +55,7 @@ def test_constant_porosity(tmpdir, datadir):
     )
     phi_expected = compact(data["dz"], data["porosity"], porosity_max=0.6)
     with tmpdir.as_cwd():
-        shutil.copy(datadir / "compact.toml", ".")
+        shutil.copy(datadir / "compaction.toml", ".")
         shutil.copy(datadir / "porosity.csv", ".")
 
         runner = CliRunner(mix_stderr=False)
@@ -80,12 +76,13 @@ def test_setup(tmpdir):
         result = runner.invoke(cli.setup)
 
         assert result.exit_code == 0
-        assert (tmpdir / "compact.toml").exists()
+        assert (tmpdir / "compaction.toml").exists()
         assert (tmpdir / "porosity.csv").exists()
 
 
 @pytest.mark.parametrize(
-    "files", (("compact.toml",), ("porosity.csv",), ("compact.toml", "porosity.csv"))
+    "files",
+    (("compaction.toml",), ("porosity.csv",), ("compaction.toml", "porosity.csv")),
 )
 def test_setup_with_existing_files(tmpdir, files):
     runner = CliRunner(mix_stderr=False)
@@ -104,9 +101,9 @@ def test_setup_with_existing_files(tmpdir, files):
 
 def test_generate(tmpdir):
     with tmpdir.as_cwd():
-        result = CliRunner(mix_stderr=False).invoke(cli.generate, ["compact.toml"])
+        result = CliRunner(mix_stderr=False).invoke(cli.generate, ["compaction.toml"])
         assert result.exit_code == 0
-        with open("compact.toml", "w") as fp:
+        with open("compaction.toml", "w") as fp:
             fp.write(result.stdout)
 
         result = CliRunner(mix_stderr=False).invoke(cli.generate, ["porosity.csv"])
@@ -122,7 +119,7 @@ def test_generate(tmpdir):
 
 def test_generate_toml(tmpdir):
     runner = CliRunner(mix_stderr=False)
-    result = runner.invoke(cli.generate, ["compact.toml"])
+    result = runner.invoke(cli.generate, ["compaction.toml"])
 
     assert result.exit_code == 0
 

--- a/tests/test_cli/compact.toml
+++ b/tests/test_cli/compact.toml
@@ -1,2 +1,0 @@
-[compact.constants]
-porosity_max = 0.6

--- a/tests/test_cli/compaction.toml
+++ b/tests/test_cli/compaction.toml
@@ -1,0 +1,2 @@
+[compaction.constants]
+porosity_max = 0.6

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -207,17 +207,17 @@ def test_load_config_defaults() -> None:
     config = load_config(StringIO("[another_group]"))
     assert config == defaults
 
-    config = load_config(StringIO("[compact]"))
+    config = load_config(StringIO("[compaction]"))
     assert config == defaults
 
-    config = load_config(StringIO("[compact]"))
+    config = load_config(StringIO("[compaction]"))
     assert config == defaults
 
 
 def test_load_config_from_file() -> None:
     """Test config vars from a file."""
     file_like = StringIO(
-        """[compact.constants]
+        """[compaction.constants]
         c = 3.14
         """
     )
@@ -246,6 +246,8 @@ def test_run(tmpdir) -> None:
 
         run_compaction("porosity.csv", "porosity-out.csv", porosity_max=0.5)
 
-        data = pandas.read_csv("porosity-out.csv", names=("dz", "porosity"), dtype=float, comment="#")
+        data = pandas.read_csv(
+            "porosity-out.csv", names=("dz", "porosity"), dtype=float, comment="#"
+        )
 
         assert np.all(data.porosity.values == approx(phi_1))


### PR DESCRIPTION
This pull request changes the name of the command line interface from *compact* to *compaction*. The name of the package is *compaction* and so having the command be *compact* was confusing.