### PR TITLE
Setup asv benchmarks

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,11 @@ include .coveragerc
 include .pre-commit-config.yaml
 include LICENSE.md
 include NEWS.md
+include asv.conf.json
 include noxfile.py
 include requirements*.in
 
 recursive-exclude news *
 recursive-exclude tests *
+
+recursive-include benchmarks *.py

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,208 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "compaction",
+
+    // The project's homepage
+    "project_url": "http://compaction.readthedocs.io/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": ".",
+
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // "repo_subdir": "",
+
+    // Customizable commands for building the project.
+    // See asv.conf.json documentation.
+    // To build the package using pyproject.toml (PEP518), uncomment the following lines
+    "build_command": [
+        "python -m pip install build",
+        "python -m build",
+        "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    ],
+    // To build the package using setuptools and a setup.py file, uncomment the following lines
+    // "build_command": [
+    //     "python setup.py build",
+    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    // ],
+
+    // Customizable commands for installing and uninstalling the project.
+    // See asv.conf.json documentation.
+    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    "branches": ["master"], // for git
+    // "branches": ["default"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv", "mamba" (above 3.8)
+    // or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    "install_timeout": 600,
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "http://github.com/mcflugen/compaction/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    // "pythons": ["3.11"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    // "conda_channels": ["conda-forge", "defaults"],
+
+    // A conda environment file that is used for environment creation.
+    // "conda_environment_file": "environment.yml",
+
+    // The matrix of dependencies to test.  Each key of the "req"
+    // requirements dictionary is the name of a package (in PyPI) and
+    // the values are version numbers.  An empty list or empty string
+    // indicates to just test against the default (latest)
+    // version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed
+    // via pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    // The ``@env`` and ``@env_nobuild`` keys contain the matrix of
+    // environment variables to pass to build and benchmark commands.
+    // An environment will be created for every combination of the
+    // cartesian product of the "@env" variables in this matrix.
+    // Variables in "@env_nobuild" will be passed to every environment
+    // during the benchmark phase, but will not trigger creation of
+    // new environments.  A value of ``null`` means that the variable
+    // will not be set for the current combination.
+    //
+    // "matrix": {
+    //     "req": {
+    //         "numpy": ["1.6", "1.7"],
+    //         "six": ["", null],  // test with and without six installed
+    //         "pip+emcee": [""]   // emcee is only available for install with pip.
+    //     },
+    //     "env": {"ENV_VAR_1": ["val1", "val2"]},
+    //     "env_nobuild": {"ENV_VAR_2": ["val3", null]},
+    // },
+	"matrix": {
+        "bmipy": [""],
+        "cython": [""],
+        "matplotlib": [""],
+        "netcdf4": [""],
+        "numpy": [""],
+        "pandas": [""],
+        "pyshp": [""],
+        "pyyaml": [""],
+        "rich-click": [""],
+        "scipy": [""],
+        "statsmodels": [""],
+        "xarray": [""]
+	},
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    // - req
+    //     Required packages
+    // - env
+    //     Environment variables
+    // - env_nobuild
+    //     Non-build environment variables
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "req": {"six": null}}, // don't run without six on conda
+    //     {"env": {"ENV_VAR_1": "val2"}}, // skip val2 for ENV_VAR_1
+    // ],
+    //
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "req": {"numpy": "1.8"}, "env_nobuild": {"FOO": "123"}},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "req": {"libpython": ""}},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": ".asv/html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+}

--- a/benchmarks/compaction_bench.py
+++ b/benchmarks/compaction_bench.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from compaction.compaction import compact
+
+
+class TimeCompaction:
+    param_names = ["layers", "columns"]
+    params = [[10, 100, 1000, 10000], [10, 100, 1000, 10000]]
+
+    def setup(self, layers, columns):
+        self.dz = np.full((layers, columns), 1.0)
+        self.phi = np.full((layers, columns), 0.5)
+        self.dz_new = np.empty_like(self.dz)
+
+    def time_without_dz(self, layers, columns):
+        compact(self.dz, self.phi, porosity_max=0.5)
+
+    def time_with_dz(self, layers, columns):
+        compact(self.dz, self.phi, porosity_max=0.5, return_dz=self.dz_new)

--- a/benchmarks/component_bench.py
+++ b/benchmarks/component_bench.py
@@ -1,0 +1,17 @@
+from landlab import RasterModelGrid
+
+from compaction.landlab import Compact
+
+
+class TimeLandlabComponent:
+    param_names = ["layers", "columns"]
+    params = [[10, 100, 1000, 10000], [10, 100, 1000, 10000]]
+
+    def setup(self, layers, columns):
+        self.grid = RasterModelGrid((3, columns))
+        for _ in range(layers):
+            self.grid.event_layers.add(1.0, porosity=0.5)
+
+    def time_component(self, layers, columns):
+        compact = Compact(self.grid, porosity_min=0.0, porosity_max=0.5)
+        compact.calculate()

--- a/news/21.misc
+++ b/news/21.misc
@@ -1,2 +1,2 @@
 
-Setup Airspeed Velocity benchmarks.
+Setup [Airspeed Velocity](https://asv.readthedocs.io/en/v0.6.1/) benchmarks.

--- a/news/21.misc
+++ b/news/21.misc
@@ -1,0 +1,2 @@
+
+Setup Airspeed Velocity benchmarks.

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,6 +22,7 @@ def test(session: nox.Session) -> None:
     session.install("-e", ".", "--no-deps")
 
     args = [
+        "--mypy",
         "--cov",
         PROJECT,
         "-vvv",

--- a/requirements-testing.in
+++ b/requirements-testing.in
@@ -1,5 +1,4 @@
 pytest
-pytest-benchmark
 pytest-cov
 pytest-datadir
 pytest-mypy

--- a/src/compaction/__init__.py
+++ b/src/compaction/__init__.py
@@ -1,4 +1,3 @@
 from ._version import __version__
-from .compaction import compact
 
-__all__ = ["__version__", "compact"]
+__all__ = ["__version__"]

--- a/src/compaction/__main__.py
+++ b/src/compaction/__main__.py
@@ -1,0 +1,4 @@
+from compaction.cli import compaction
+
+if __name__ == "__main__":
+    raise SystemExit(compaction())

--- a/src/compaction/cli.py
+++ b/src/compaction/cli.py
@@ -11,7 +11,7 @@ import numpy as np  # type: ignore
 import pandas  # type: ignore
 import tomlkit as toml  # type: ignore
 
-from .compaction import compact as _compact
+from compaction.compaction import compact as _compact
 
 out = partial(click.secho, bold=True, err=True)
 err = partial(click.secho, fg="red", err=True)
@@ -115,7 +115,7 @@ def load_config(stream: TextIO | None = None):
     }
     if stream is not None:
         try:
-            local_params = toml.parse(stream.read())["compaction"]
+            local_params = toml.parse(stream.read()).value["compaction"]
         except KeyError:
             local_params = {"constants": {}}
 

--- a/src/compaction/compaction.py
+++ b/src/compaction/compaction.py
@@ -1,4 +1,6 @@
 #! /usr/bin/env python
+from __future__ import annotations
+
 import numpy as np  # type: ignore
 from scipy.constants import g  # type: ignore
 

--- a/src/compaction/landlab.py
+++ b/src/compaction/landlab.py
@@ -2,7 +2,7 @@
 from landlab import Component  # type: ignore
 from scipy.constants import g  # type: ignore
 
-from .compaction import compact
+from compaction import compaction
 
 
 class Compact(Component):
@@ -100,7 +100,9 @@ class Compact(Component):
         dz = self._grid.event_layers.dz[-1::-1, :]
         porosity = self._grid.event_layers["porosity"][-1::-1, :]
 
-        porosity[:] = compact(dz, porosity, return_dz=dz, **self._compaction_params)
+        porosity[:] = compaction.compact(
+            dz, porosity, return_dz=dz, **self._compaction_params
+        )
 
         return self.grid
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,8 @@ import tomlkit  # type: ignore
 from click.testing import CliRunner
 from numpy.testing import assert_array_almost_equal  # type: ignore
 
-from compaction import cli, compact
+from compaction import cli
+from compaction.compaction import compact
 
 
 def test_command_line_interface():

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -5,8 +5,8 @@ import numpy as np  # type: ignore
 import pandas  # type: ignore
 from pytest import approx, mark, raises  # type: ignore
 
-from compaction import compact
 from compaction.cli import load_config, run_compaction
+from compaction.compaction import compact
 
 
 def test_to_analytical() -> None:
@@ -52,13 +52,10 @@ def test_spatially_distributed() -> None:
 
 
 @mark.parametrize("size", (10, 100, 1000, 10000))
-@mark.benchmark(group="compaction")
-def test_grid_size(benchmark, size) -> None:
+def test_grid_size(size) -> None:
     dz = np.full((size, 100), 1.0)
     phi = np.full((size, 100), 0.5)
     phi_new = compact(dz, phi, porosity_max=0.5)
-
-    phi_new = benchmark(compact, dz, phi, porosity_max=0.5)
 
     assert phi_new[0] == approx(phi[0])
     assert np.all(phi_new[1:] < phi[1:])
@@ -66,14 +63,12 @@ def test_grid_size(benchmark, size) -> None:
 
 
 @mark.parametrize("size", (10, 100, 1000, 10000))
-@mark.benchmark(group="compaction-with-dz")
-def test_grid_size_with_dz(benchmark, size) -> None:
+def test_grid_size_with_dz(size) -> None:
     dz = np.full((size, 100), 1.0)
     phi = np.full((size, 100), 0.5)
-    phi_new = compact(dz, phi, porosity_max=0.5)
-
     dz_new = np.empty_like(dz)
-    phi_new = benchmark(compact, dz, phi, porosity_max=0.5, return_dz=dz_new)
+
+    phi_new = compact(dz, phi, porosity_max=0.5, return_dz=dz_new)
 
     assert phi_new[0] == approx(phi[0])
     assert np.all(phi_new[1:] < phi[1:])

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -34,14 +34,13 @@ def test_init_without_layers_added(grid):
 
 
 @mark.parametrize("size", (10, 100, 1000, 10000))
-@mark.benchmark(group="landlab")
-def test_grid_size(benchmark, size):
+def test_grid_size(size):
     grid = RasterModelGrid((3, 101))
     for _ in range(size):
         grid.event_layers.add(1.0, porosity=0.5)
 
     compact = Compact(grid, porosity_min=0.0, porosity_max=0.5)
-    benchmark(compact.calculate)
+    compact.calculate()
 
     assert np.all(grid.event_layers["porosity"][:-1] < 0.5)
     assert grid.event_layers["porosity"][-1] == approx(0.5)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -4,7 +4,7 @@ from landlab import RasterModelGrid  # type: ignore
 from numpy.testing import assert_array_almost_equal  # type: ignore
 from pytest import approx, fixture, mark, raises  # type: ignore
 
-import compaction
+from compaction import compaction
 from compaction.landlab import Compact
 
 


### PR DESCRIPTION
In this pull request I've moved the benchmarks from *pytest-benchmarks* to [Airspeed Velocity](https://asv.readthedocs.io/en/v0.6.1/).